### PR TITLE
Fix SKBitmap disposal for split pages

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -176,6 +176,12 @@ namespace read_journal_documentanalysis
                     ref totalWordConf,
                     ref totalWordCount,
                     aggWriter);
+
+                // Dispose temporary bitmaps created for split pages to
+                // release native memory. The original full bitmap is
+                // disposed by the surrounding using statement.
+                if (!ReferenceEquals(bmp, full))
+                    bmp.Dispose();
             }
         }
 


### PR DESCRIPTION
## Summary
- dispose split page bitmaps after processing to free native memory

## Testing
- `dotnet build read-journal-fr.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6877cee415308331a4daba9dbfc38e6d